### PR TITLE
Improve top-level command descriptions; add Handbook links

### DIFF
--- a/src/Capabilities_Command.php
+++ b/src/Capabilities_Command.php
@@ -3,7 +3,7 @@
 /**
  * Adds, removes, and lists capabilities of a user role.
  *
- * See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities)and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).
+ * See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities) and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).
  *
  * ## EXAMPLES
  *

--- a/src/Capabilities_Command.php
+++ b/src/Capabilities_Command.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * Manage user capabilities.
+ * Adds, removes, and lists capabilities of a user role.
+ *
+ * See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities)and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).
  *
  * ## EXAMPLES
  *

--- a/src/Role_Command.php
+++ b/src/Role_Command.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * Manage user roles.
+ * Manages user roles, including creating new roles and resetting to defaults.
+ *
+ * See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities)and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).
  *
  * ## EXAMPLES
  *

--- a/src/Role_Command.php
+++ b/src/Role_Command.php
@@ -3,7 +3,7 @@
 /**
  * Manages user roles, including creating new roles and resetting to defaults.
  *
- * See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities)and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).
+ * See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities) and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).
  *
  * ## EXAMPLES
  *


### PR DESCRIPTION
Related: [/wp-cli/issues/4302](https://github.com/wp-cli/wp-cli/issues/4302)

Changes:
___
Improve 'wp cap' command description in:
https://github.com/wp-cli/role-command/blob/master/src/Capabilities_Command.php
Command: wp cap
Current description: Manage user capabilities.

New description:
Adds, removes, and lists capabilities of a user role.

See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities)and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).

___
Improve command description in:
https://github.com/wp-cli/role-command/blob/master/src/Role_Command.php
Command: wp role
Current description: Manage user roles.

New description:
Manages user roles, including creating new roles and resetting to defaults.

See references for [Roles and Capabilities](https://codex.wordpress.org/Roles_and_Capabilities)and [WP User class](https://codex.wordpress.org/Class_Reference/WP_User).