### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor/
 *.tar.gz
 composer.lock
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "wp-cli/wp-cli": "^2"
     },
     "require-dev": {
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,4 +51,8 @@
 		</properties>
 	</rule>
 
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/(Role|Capabilities)_Command\.php$</exclude-pattern>
+	</rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-role">
+	<description>Custom ruleset for WP-CLI role-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\Role"/><!-- Namespaces. -->
+				<element value="wpcli_role"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/role-command.php
+++ b/role-command.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+$wpcli_role_autoloader = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $wpcli_role_autoloader ) ) {
+	require_once $wpcli_role_autoloader;
 }
 
 WP_CLI::add_command( 'cap', 'Capabilities_Command' );

--- a/src/Capabilities_Command.php
+++ b/src/Capabilities_Command.php
@@ -23,6 +23,11 @@ use WP_CLI\Formatter;
  */
 class Capabilities_Command extends WP_CLI_Command {
 
+	/**
+	 * List of available fields.
+	 *
+	 * @var array
+	 */
 	private $fields = [ 'name' ];
 
 	/**
@@ -199,6 +204,13 @@ class Capabilities_Command extends WP_CLI_Command {
 		WP_CLI::success( sprintf( $message, $count, $role ) );
 	}
 
+	/**
+	 * Retrieve a specific role from the system.
+	 *
+	 * @param string $role Role to retrieve.
+	 * @return WP_Role Requested role.
+	 * @throws \WP_CLI\ExitException If the role could not be found.
+	 */
 	private static function get_role( $role ) {
 		global $wp_roles;
 
@@ -211,6 +223,12 @@ class Capabilities_Command extends WP_CLI_Command {
 		return $role_obj;
 	}
 
+	/**
+	 * Assert that the roles are persisted to the database.
+	 *
+	 * @throws \WP_CLI\ExitException If the roles are not persisted to the
+	 *                               database.
+	 */
 	private static function persistence_check() {
 		global $wp_roles;
 

--- a/src/Capabilities_Command.php
+++ b/src/Capabilities_Command.php
@@ -1,5 +1,7 @@
 <?php
 
+use WP_CLI\Formatter;
+
 /**
  * Adds, removes, and lists capabilities of a user role.
  *
@@ -21,9 +23,7 @@
  */
 class Capabilities_Command extends WP_CLI_Command {
 
-	private $fields = array(
-		'name'
-	);
+	private $fields = [ 'name' ];
 
 	/**
 	 * Lists capabilities for a given role.
@@ -45,7 +45,7 @@ class Capabilities_Command extends WP_CLI_Command {
 	 *   - count
 	 *   - yaml
 	 * ---
-	 * 
+	 *
 	 * [--show-grant]
 	 * : Display all capabilities defined for a role including grant.
 	 * ---
@@ -66,24 +66,23 @@ class Capabilities_Command extends WP_CLI_Command {
 	 */
 	public function list_( $args, $assoc_args ) {
 		$role_obj = self::get_role( $args[0] );
-		
+
 		$show_grant = ! empty( $assoc_args['show-grant'] );
 
 		if ( $show_grant ) {
 			array_push( $this->fields, 'grant' );
 			$capabilities = $role_obj->capabilities;
-		} 
-		else {
+		} else {
 			$capabilities = array_filter( $role_obj->capabilities );
 		}
-		
+
 		$output_caps = array();
 		foreach ( $capabilities as $cap => $grant ) {
-			$output_cap = new StdClass;
+			$output_cap = new stdClass();
 
-			$output_cap->name = $cap;
+			$output_cap->name  = $cap;
 			$output_cap->grant = ( $grant ) ? 'true' : 'false';
-			
+
 			$output_caps[] = $output_cap;
 		}
 
@@ -91,14 +90,12 @@ class Capabilities_Command extends WP_CLI_Command {
 			foreach ( $output_caps as $cap ) {
 				if ( $show_grant ) {
 					WP_CLI::line( implode( ',', array( $cap->name, $cap->grant ) ) );
-				} 
-				else {
+				} else {
 					WP_CLI::line( $cap->name );
 				}
 			}
-		}
-		else {
-			$formatter = new \WP_CLI\Formatter( $assoc_args, $this->fields );
+		} else {
+			$formatter = new Formatter( $assoc_args, $this->fields );
 			$formatter->display_items( $output_caps );
 		}
 	}
@@ -113,7 +110,7 @@ class Capabilities_Command extends WP_CLI_Command {
 	 *
 	 * <cap>...
 	 * : One or more capabilities to add.
-	 * 
+	 *
 	 * [--grant]
 	 * : Adds the capability as an explicit boolean value, instead of implicitly defaulting to `true`.
 	 * ---
@@ -141,11 +138,13 @@ class Capabilities_Command extends WP_CLI_Command {
 		$count = 0;
 
 		foreach ( $args as $cap ) {
-			if ( true === $grant && $role_obj->has_cap( $cap ) )
+			if ( true === $grant && $role_obj->has_cap( $cap ) ) {
 				continue;
+			}
 
-			if ( false === $grant && isset( $role_obj->capabilities[ $cap ] ) && false === $role_obj->capabilities[ $cap ] )
+			if ( false === $grant && isset( $role_obj->capabilities[ $cap ] ) && false === $role_obj->capabilities[ $cap ] ) {
 				continue;
+			}
 
 			$role_obj->add_cap( $cap, $grant );
 
@@ -187,8 +186,9 @@ class Capabilities_Command extends WP_CLI_Command {
 		$count = 0;
 
 		foreach ( $args as $cap ) {
-			if ( ! isset( $role_obj->capabilities[ $cap ] ) )
+			if ( ! isset( $role_obj->capabilities[ $cap ] ) ) {
 				continue;
+			}
 
 			$role_obj->remove_cap( $cap );
 
@@ -204,8 +204,9 @@ class Capabilities_Command extends WP_CLI_Command {
 
 		$role_obj = $wp_roles->get_role( $role );
 
-		if ( !$role_obj )
-			WP_CLI::error( "'$role' role not found." );
+		if ( ! $role_obj ) {
+			WP_CLI::error( "'{$role}' role not found." );
+		}
 
 		return $role_obj;
 	}
@@ -213,7 +214,8 @@ class Capabilities_Command extends WP_CLI_Command {
 	private static function persistence_check() {
 		global $wp_roles;
 
-		if ( !$wp_roles->use_db )
-			WP_CLI::error( "Role definitions are not persistent." );
+		if ( ! $wp_roles->use_db ) {
+			WP_CLI::error( 'Role definitions are not persistent.' );
+		}
 	}
 }

--- a/src/Capabilities_Command.php
+++ b/src/Capabilities_Command.php
@@ -86,7 +86,7 @@ class Capabilities_Command extends WP_CLI_Command {
 			$output_cap = new stdClass();
 
 			$output_cap->name  = $cap;
-			$output_cap->grant = ( $grant ) ? 'true' : 'false';
+			$output_cap->grant = $grant ? 'true' : 'false';
 
 			$output_caps[] = $output_cap;
 		}
@@ -156,12 +156,10 @@ class Capabilities_Command extends WP_CLI_Command {
 			$count++;
 		}
 
-		if ( $grant ) {
-			$message = ( 1 === $count ) ? "Added %d capability to '%s' role." : "Added %d capabilities to '%s' role.";
-		} else {
-			$message = ( 1 === $count ) ? "Added %d capability to '%s' role as false." : "Added %d capabilities to '%s' role as false.";
-		}
-		WP_CLI::success( sprintf( $message, $count, $role ) );
+		$capability          = WP_CLI\Utils\pluralize( 'capability', $count );
+		$grant_qualification = $grant ? '' : ' as false';
+
+		WP_CLI::success( "Added {$count} {$capability} to '{$role}' role{$grant_qualification}." );
 	}
 
 	/**
@@ -200,8 +198,9 @@ class Capabilities_Command extends WP_CLI_Command {
 			$count++;
 		}
 
-		$message = ( 1 === $count ) ? "Removed %d capability from '%s' role." : "Removed %d capabilities from '%s' role.";
-		WP_CLI::success( sprintf( $message, $count, $role ) );
+		$capability = WP_CLI\Utils\pluralize( 'capability', $count );
+
+		WP_CLI::success( "Removed {$count} {$capability} from '{$role}' role." );
 	}
 
 	/**

--- a/src/Role_Command.php
+++ b/src/Role_Command.php
@@ -192,9 +192,9 @@ class Role_Command extends WP_CLI_Command {
 				foreach ( $capabilities as $cap ) {
 					$role_obj->add_cap( $cap );
 				}
-				WP_CLI::success( sprintf( "Role with key '%s' created. Cloned capabilities from '%s'.", $role_key, $assoc_args['clone'] ) );
+				WP_CLI::success( "Role with key '{$role_key}' created. Cloned capabilities from '{$assoc_args['clone']}'." );
 			} else {
-				WP_CLI::success( sprintf( "Role with key '%s' created.", $role_key ) );
+				WP_CLI::success( "Role with key '{$role_key}' created." );
 			}
 		} else {
 			WP_CLI::error( "Role couldn't be created." );
@@ -235,9 +235,9 @@ class Role_Command extends WP_CLI_Command {
 		// Note: remove_role() doesn't indicate success or otherwise, so we have to
 		// check ourselves
 		if ( ! isset( $wp_roles->roles[ $role_key ] ) ) {
-			WP_CLI::success( sprintf( "Role with key '%s' deleted.", $role_key ) );
+			WP_CLI::success( "Role with key '{$role_key}' deleted." );
 		} else {
-			WP_CLI::error( sprintf( "Role with key '%s' could not be deleted.", $role_key ) );
+			WP_CLI::error( "Role with key '{$role_key}' could not be deleted." );
 		}
 
 	}

--- a/src/Role_Command.php
+++ b/src/Role_Command.php
@@ -39,9 +39,18 @@ use WP_CLI\Formatter;
  */
 class Role_Command extends WP_CLI_Command {
 
+	/**
+	 * Available fields.
+	 *
+	 * @var array
+	 */
 	private $fields = [ 'name', 'role' ];
 
-	// Array of default roles.
+	/**
+	 * Default roles ad provided by WordPress Core.
+	 *
+	 * @var array
+	 */
 	private $roles = [ 'administrator', 'editor', 'author', 'contributor', 'subscriber' ];
 
 	/**
@@ -377,6 +386,12 @@ class Role_Command extends WP_CLI_Command {
 		}
 	}
 
+	/**
+	 * Assert that the roles are persisted to the database.
+	 *
+	 * @throws \WP_CLI\ExitException If the roles are not persisted to the
+	 *                               database.
+	 */
 	private static function persistence_check() {
 		global $wp_roles;
 

--- a/src/Role_Command.php
+++ b/src/Role_Command.php
@@ -40,14 +40,14 @@ use WP_CLI\Formatter;
 class Role_Command extends WP_CLI_Command {
 
 	/**
-	 * Available fields.
+	 * List of available fields.
 	 *
 	 * @var array
 	 */
 	private $fields = [ 'name', 'role' ];
 
 	/**
-	 * Default roles ad provided by WordPress Core.
+	 * Default roles as provided by WordPress Core.
 	 *
 	 * @var array
 	 */


### PR DESCRIPTION
Add a PHPCS ruleset using the new `WP_CLI_CS` standard.

Fixes #31

Related https://github.com/wp-cli/wp-cli/issues/5179